### PR TITLE
fix: pipeline fail while generating docker image

### DIFF
--- a/.github/workflows/CICD.yml
+++ b/.github/workflows/CICD.yml
@@ -5,7 +5,7 @@ on:
     paths-ignore:
       - '**.md'
   pull_request:
-    types: [ opened, synchronize, edited ]
+    types: [ opened, reopened ,synchronize]
 
 jobs:
   CI:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -216,3 +216,11 @@ private infix fun String.from(properties: Properties): String =
     } else {
         error("Property '$this' not found.")
     }
+
+ktlint {
+    filter {
+        exclude { entry ->
+            entry.file.toString().contains("generated")
+        }
+    }
+}


### PR DESCRIPTION
# what have been done
- add exclude for generated files from being checked by `ktlint`
- make workflow not fired when edit description of PR.

# Context 
after we run `make build-app` it will generate files at folder `*/generated/*` which files not have lint formatted, so it failing the check of lint.

check [here](https://github.com/u-ways/spring-boot-reactive-microservice-kt/actions/runs/11332450964/job/31514753581)  


# Test 
[here](https://github.com/MahmoudMabrok/spring-boot-reactive-microservice-kt/actions/runs/11392033785/job/31697322128) all check passed. 

