### PR TITLE
Update Code Climate Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Spring Boot Reactive Microservice (Kt)
 
 [![CICD](https://github.com/u-ways/spring-boot-reactive-microservice-kt/actions/workflows/CICD.yml/badge.svg)](https://github.com/u-ways/spring-boot-reactive-microservice-kt/actions/workflows/CICD.yml)
-[![Code Climate](https://codeclimate.com/github/u-ways/spring-boot-reactive-microservice-kt.png)](https://codeclimate.com/github/u-ways/spring-boot-reactive-microservice-kt)
+[![Code Climate](https://badgen.net/badge/CodeClimate/A/green)](https://codeclimate.com/github/u-ways/spring-boot-reactive-microservice-kt)
 [![GitHub License](https://badgen.net/badge/license/BSD-3-Clause/blue)](https://github.com/u-ways/spring-boot-reactive-microservice-kt/blob/master/LICENSE)
 [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 


### PR DESCRIPTION
It seems code climate is down, let's use  this bade until then: https://codeclimate.com/explore

<img width="740" height="493" alt="image" src="https://github.com/user-attachments/assets/7842d9b5-6968-4fb3-9f4b-8123e1362646" />